### PR TITLE
Added option to add custom path inside 'trunk'

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -59,6 +59,10 @@ function buildDepObj(str, deps) {
         out.tag = str[2];
         out.rev = str[3];
         if (out.tag.toLowerCase() != "trunk") out.repo = out.repo + "/tags/";
+    } else if(str.contains("/trunk/")) {
+        out.name = str;
+        out.tag = "";
+        out.rev = "HEAD";
     } else {
         out.name = str;
         out.tag = "trunk";

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -59,7 +59,7 @@ function buildDepObj(str, deps) {
         out.tag = str[2];
         out.rev = str[3];
         if (out.tag.toLowerCase() != "trunk") out.repo = out.repo + "/tags/";
-    } else if(str.contains("/trunk/")) {
+    } else if(str.indexOf("/trunk/") > 0) {
         out.name = str;
         out.tag = "";
         out.rev = "HEAD";

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -59,7 +59,7 @@ function buildDepObj(str, deps) {
         out.tag = str[2];
         out.rev = str[3];
         if (out.tag.toLowerCase() != "trunk") out.repo = out.repo + "/tags/";
-    } else if(str.indexOf("/trunk/") > 0) {
+    } else if(out.repo.indexOf("/trunk/") > 0) {
         out.name = str;
         out.tag = "";
         out.rev = "HEAD";


### PR DESCRIPTION
Solved the issue I created earlier today  #1 

Checks if the out.repo contains "/trunk/" and if it does it won't add "/trunk" at the end.
Example usage:
`"svnDependencies": {
 "svn-module": "svn://path/to/svn/repo/trunk/specificFolderInRepo"
}`

This currently cannot be combined with '@tag' or '@tag|revision'. 