### PR TITLE
Directories with spaces break SVN update and cleanup calls

### DIFF
--- a/src/scanner.js
+++ b/src/scanner.js
@@ -165,7 +165,7 @@ function checkout(dep) {
 
 function update(dep) {
     return function (callback) {
-        return svn.update(rootDir + "/" + dep.installDir,
+        return svn.update([rootDir + "/" + dep.installDir],
             Object.assign({revision: dep.rev}, svnOptions),
             function (error, result) {
             //console.log("UP", result);
@@ -176,7 +176,7 @@ function update(dep) {
 
 function cleanup(dep) {
     return function (callback) {
-        return svn.cleanup(rootDir + "/" + dep.installDir, svnOptions, function (error, result) {
+        return svn.cleanup([rootDir + "/" + dep.installDir], svnOptions, function (error, result) {
             //console.log("Cleanup", result);
             return callback(error ? result : null)
         })


### PR DESCRIPTION
I changed the way that the installDir was passed to the SVN update and cleanup methods to work around a problem that would arise when the path had a space in it. The SVN package interprets a string passed to these services as a space delimited list of files. If passed an array of strings, the path will be used as is.